### PR TITLE
fix: remove githubAadvisoryId

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,22 +6,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: yarn
       - run: yarn lint
+      - run: yarn test
 
   publish-npm:
     if: contains(github.ref, 'master')
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: yarn
       - run: npx semantic-release
         env:
@@ -33,10 +34,10 @@ jobs:
     needs: publish-npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://npm.pkg.github.com/
           token: ${{ secrets.GH_TOKEN }}
       - run: |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports = {
     ],
 }
 ```
-* githubAadvisoryId: The Github Advisory ID of the entry you wish to suppress
+* githubAdvisoryId: The Github Advisory ID of the entry you wish to suppress
 * suppress.until: The validity of the grace period until this audit is finished with error
 * suppress.reason: A note for yourself, to remember why you are suppressing this advisory
 
@@ -72,3 +72,4 @@ Version history
 * 1.0.0: Initial release
 * 1.0.1: Ignore licence check
 * 1.0.2: Treat "Unknown error" as failure
+* 2.0.0: removed `githubAadvisoryId` in favor of `githubAdvisoryId` in `suppressions.js` file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@competec/yarn-audit-competec",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Competec Audit-Modules",
   "private": false,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "audit-competec": "./bin/yarn-audit-competec.js"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=6.14.4"
   },
   "author": "Francis C. / Competec",

--- a/src/utils/__snapshots__/isSuppressed.test.js.snap
+++ b/src/utils/__snapshots__/isSuppressed.test.js.snap
@@ -1,10 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should return a logger with info: An advisory has been found... 1`] = `
-Array [
-  Array [
-    "An advisory has been found. You can suppress this in /Users/monikamalecka/shop3/yarn-audit-competec/.yarn-audit-competec/suppressions.js",
-    Object {
+[
+  [
+    "An advisory has been found. You can suppress this in .yarn-audit-competec/suppressions.js",
+    {
+      "findings": "test",
+      "githubAdvisoryId": "id",
+    },
+  ],
+  [
+    "An advisory has been found. You can suppress this in .yarn-audit-competec/suppressions.js",
+    {
       "findings": "test",
       "githubAdvisoryId": "GHSA-hjp8-2cm3-cc45",
     },
@@ -13,10 +20,24 @@ Array [
 `;
 
 exports[`should return a logger with info: Suppression has expired... 1`] = `
-Array [
-  Array [
+[
+  [
+    "An advisory has been found. You can suppress this in .yarn-audit-competec/suppressions.js",
+    {
+      "findings": "test",
+      "githubAdvisoryId": "id",
+    },
+  ],
+  [
+    "An advisory has been found. You can suppress this in .yarn-audit-competec/suppressions.js",
+    {
+      "findings": "test",
+      "githubAdvisoryId": "GHSA-hjp8-2cm3-cc45",
+    },
+  ],
+  [
     "Suppression has expired!",
-    Object {
+    {
       "findings": "test",
       "githubAdvisoryId": "GHSA-hjp8-2cm3-cc45",
     },

--- a/src/utils/isSuppressed.test.js
+++ b/src/utils/isSuppressed.test.js
@@ -5,20 +5,28 @@ const logger = require('./logger');
 jest.mock('./logger');
 const mockedLogger = jest.mocked(logger);
 
+jest.mock('../config', () => ({
+    APP_PREFIX: 'yarn-audit-competec',
+    SUPPRESSION_FILE: `.yarn-audit-competec/suppressions.js`,
+    REPORT_RAW_FILE: 'report-raw.txt',
+    REPORT_STATS_FILE: `.yarn-audit-competec/stats.json`,
+}));
+
+
 test('should return true', () => {
     const suppressionList =
            [
                {
-                   githubAadvisoryId: 'GHSA-hjp8-2cm3-cc45',
+                   githubAdvisoryId: 'GHSA-hjp8-2cm3-cc45',
                    suppress: {
-                       until: '2022-12-31Z',
+                       until: '2030-12-31Z',
                        reason: 'Third party',
                    },
                },
                {
                    githubAdvisoryId: 'GHSA-hhq3-ff78-jv3g',
                    suppress: {
-                       until: '2023-03-31Z',
+                       until: '2030-03-31Z',
                        reason: 'eslint-loader, resolve-url-loader, react-dev-utils',
                    },
                },
@@ -39,7 +47,7 @@ test('should return false', () => {
             {
                 githubAadvisoryId: 'GHSA-hjp8-2cm3-cc45',
                 suppress: {
-                    until: '2022-12-31Z',
+                    until: '2030-12-31Z',
                     reason: 'Third party',
                 },
             },


### PR DESCRIPTION
BREAKING CHANGE: removed `githubAadvisoryId` in favor of `githubAdvisoryId` in suppressions.js file